### PR TITLE
add build system based on jconfigpy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,79 @@
-.PHONY : all debug release
-.SUFFIXES : .cpp .o
+-include .config
 
-SOURCES := $(wildcard *.cpp)
-INCLUDES :=
-OBJECTS := $(SOURCES:.cpp=.o)
+.PHONY : all debug release clean
+
+
+DBG_CPPFLAGS := -g2 -O0 -Wall -fPIC -D__DBG
+REL_CPPFLAGS := -g0 -O2 -Wall -fPIC
+
+
+INCLUDES := $(INC-y:%=-I%)
 LIBRARY :=
-CPP := g++
 
-TARGET = libnc.a
+MKDIR=mkdir
+CXX := g++
+PY=python
+PIP=pip
+
+CONFIG_ENTRY:=./config.json
+CONFIG_TARGET:=./.config
+CONFIG_AUTOGEN=./$(AUTOGEN_DIR)/autogen.h
+
+DBG_OBJS=$(OBJ-y:%=$(DBG_OBJ_CACHE)/%.do)
+REL_OBJS=$(OBJ-y:%=$(REL_OBJ_CACHE)/%.o)
+
+AUTOGEN_DIR=autogen
+DBG_OBJ_CACHE:=Debug
+REL_OBJ_CACHE:=Release
+TOOL_DIR:=tools
+
+JCONFIGPY=$(TOOL_DIR)/jconfigpy/jconfigpy.py
+
+DBG_TARGET:=libncd.a
+REL_TARGET:=libnc.a
+
+SILENT= $(DBG_TARGET) $(REL_TARGET) $(DBG_OBJ_CACHE) $(REL_OBJ_CACHE) $(DBG_OBJS) $(REL_OBJS) \
+		debug release clean
+.SILENT : $(SILENT)
+VPATH:=$(SRC-y)
 
 all : debug
 
-$(TARGET) : $(OBJECTS)
-	$(AR) rs $@ $^
+config : $(AUTOGEN_DIR) $(JCONFIGPY)
+	$(PY) $(JCONFIGPY) -c -i $(CONFIG_ENTRY) -o $(CONFIG_TARGET) -g $(CONFIG_AUTOGEN)
+	
+$(JCONFIGPY) : 
+	$(PIP) install jconfigpy -t $(TOOL_DIR) 
 
-.cpp.o : $(SOURCES)
-	$(CPP) $(CPPFLAGS) $(INCLUDES) $(SOURCES)
+debug : $(DBG_OBJ_CACHE) $(DBG_TARGET)
+
+release : $(REL_OBJ_CACHE) $(REL_TARGET)
+
+$(DBG_TARGET): $(DBG_OBJS)
+	@echo 'archiving...$@'
+	$(AR) rcs $@ $(DBG_OBJS)
+
+$(REL_TARGET): $(REL_OBJS) 
+	@echo 'archiving...$@'
+	$(AR) rcs $@ $(REL_OBJS)
+
+$(DBG_OBJ_CACHE)/%.do : %.cpp
+	@echo 'compile...$@'
+	$(CXX) -c -o $@ $(INCLUDES) $(LIBRARY) $(CPPFLAGS) $<
+	
+$(REL_OBJ_CACHE)/%.o : %.cpp
+	@echo 'compile...$@'
+	$(CXX) -c -o $@ $(INCLUDES) $(LIBRARY) $(CPPFLAGS) $<
+	
+$(DBG_OBJ_CACHE) $(REL_OBJ_CACHE) $(AUTOGEN_DIR) :
+	$(MKDIR) $@
 
 clean:
-	rm -rf $(OBJECTS) $(TARGET) *~
-
-debug : CPPFLAGS := -g -c -Wall -fPIC
-debug : $(TARGET)
-
-release : CPPFLAGS := -O0 -c -Wall -fPIC
-release : $(TARGET)
+	@echo 'clean all'
+	rm -rf $(REL_OBJ_CACHE) $(REL_TARGET) $(DBG_OBJ_CACHE) $(DBG_TARGET) \
+			$(DBG_OBJS) $(REL_OBJS) 
+			
+config_clean :
+	@echo 'clean configuration'
+	rm -rf $(AUTOGEN_DIR) $(CONFIG_TARGET) $(CONFIG_AUTOGEN)
 

--- a/autogen/autogen.h
+++ b/autogen/autogen.h
@@ -1,0 +1,3 @@
+#ifndef ___AUTO_GEN_H
+#define ___AUTO_GEN_H
+#endif

--- a/config.json
+++ b/config.json
@@ -1,0 +1,6 @@
+{
+	"ROOT_RECIPE" : {
+		"type":"recipe",
+		"path":"recipe.mk"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+	"name":"nc",
+	"include":["./"],
+	"output":["libnc.a"],
+	"version":"0.1",
+	"buildcmd":[
+		"make config",
+		"make release"
+	]
+}

--- a/recipe.mk
+++ b/recipe.mk
@@ -1,0 +1,4 @@
+OBJ-y+= finite_field \
+		nc_codec 
+INC-y+=./
+SRC-y+=./


### PR DESCRIPTION
- by typing 'make config' in shell project will be ready to be built

can be integrated any jconfigpy project
- package.json is added so any project using jconfigpy can integrate easily